### PR TITLE
Fixes issue #3

### DIFF
--- a/game.js
+++ b/game.js
@@ -190,6 +190,7 @@ function handleKeydown(event) {
 }
 
 function submitWord() {
+	submitButton.focus();
 	const workingWord = workingWordDiv.textContent;
 	const letterButtons = document.querySelectorAll(".letter-button");
 


### PR DESCRIPTION
  The bug was that when you clicked on a letter button, the browser
  would focus on that letter button and when you pressed the enter
  button, the handleButtonClick and handleKeydown would both fire.

  That caused the most recently clicked (which is also focused) button
  to regain it's "selected" class and be pushed to the selectedButtons
  array.

  The workingWord would be empty and you are left with one letter
  button that is "selected".

  Once you started typing again, because the focused button was
  in the selectedButtons array, updateWorkingWord would push that to the
  workingWord string which would then be the textContent of the
  workingWordDiv.

  This doesn't occur when you just click on the "Submit" button.

  Making the submitButton focused once you pressed "Enter" fixes the
  focus issue, but anything else being focused/can be focused besides the
  letter buttons also fixes this.

 Closes #3 
